### PR TITLE
🔀 :: (#97) 버그 해결

### DIFF
--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/company/mapper/CompanyMapper.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/company/mapper/CompanyMapper.java
@@ -25,7 +25,7 @@ public class CompanyMapper {
         UserEntity user = userPersistenceAdapter.findUserById(company.getUserId())
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
         return CompanyEntity.builder()
-                .user(user)
+                .userEntity(user)
                 .companyName(company.getCompanyName())
                 .build();
     }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/company/persistence/CompanyPersistenceAdapter.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/company/persistence/CompanyPersistenceAdapter.java
@@ -20,7 +20,7 @@ public class CompanyPersistenceAdapter implements QueryCompanyPort, CommandCompa
     @Override
     public Company findCompanyByUserId(UUID userId) {
         return companyMapper.entityToDomain(
-                companyRepository.findByUserId(userId)
+                companyRepository.findByUserEntityId(userId)
                         .orElseThrow(() -> CompanyNotFoundException.EXCEPTION)
         );
     }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/company/persistence/CompanyRepository.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/company/persistence/CompanyRepository.java
@@ -6,5 +6,5 @@ import kr.hs.entrydsm.yapaghetti.domain.company.persistence.entity.CompanyEntity
 import org.springframework.data.repository.CrudRepository;
 
 public interface CompanyRepository extends CrudRepository<CompanyEntity, UUID> {
-    Optional<CompanyEntity> findByUserId(UUID userId);
+    Optional<CompanyEntity> findByUserEntityId(UUID userId);
 }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/company/persistence/entity/CompanyEntity.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/company/persistence/entity/CompanyEntity.java
@@ -31,7 +31,7 @@ public class CompanyEntity {
 	@MapsId
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
-	private UserEntity user;
+	private UserEntity userEntity;
 
 	@Column(columnDefinition = "VARCHAR(40)", nullable = false)
 	private String companyName;

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/document/mapper/DocumentMapper.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/document/mapper/DocumentMapper.java
@@ -32,7 +32,7 @@ public class DocumentMapper {
                 .previewImagePath(document.getPreviewImagePath())
                 .content(document.getContent())
                 .type(document.getType())
-                .user(userEntity)
+                .userEntity(userEntity)
                 .build();
     }
 }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/document/persistence/DocumentPersistenceAdapter.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/document/persistence/DocumentPersistenceAdapter.java
@@ -47,7 +47,7 @@ public class DocumentPersistenceAdapter implements CommandDocumentPort, QueryDoc
     @Override
     public Document queryDocumentByUserIdAndType(UUID userId, DocumentType type) {
         return documentMapper.entityToDomain(
-                documentRepository.findByUserIdAndType(userId, type)
+                documentRepository.findByUserEntityIdAndType(userId, type)
                         .orElseThrow(() -> DocumentNotFoundException.EXCEPTION)
         );
     }
@@ -55,7 +55,7 @@ public class DocumentPersistenceAdapter implements CommandDocumentPort, QueryDoc
     @Override
     public Document queryDocumentByIdAndUserIdAndType(UUID documentId, UUID userId, DocumentType type) {
         return documentMapper.entityToDomain(
-                documentRepository.findByIdAndUserIdAndType(documentId, userId, type)
+                documentRepository.findByIdAndUserEntityIdAndType(documentId, userId, type)
                         .orElseThrow(() -> DocumentNotFoundException.EXCEPTION)
         );
     }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/document/persistence/DocumentRepository.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/document/persistence/DocumentRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface DocumentRepository extends CrudRepository<DocumentEntity, UUID> {
-    Optional<DocumentEntity> findByUserIdAndType(UUID userId, DocumentType type);
+    Optional<DocumentEntity> findByUserEntityIdAndType(UUID userId, DocumentType type);
 
-    Optional<DocumentEntity> findByIdAndUserIdAndType(UUID documentId, UUID userId, DocumentType type);
+    Optional<DocumentEntity> findByIdAndUserEntityIdAndType(UUID id, UUID userId, DocumentType type);
 }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/document/persistence/entity/DocumentEntity.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/document/persistence/entity/DocumentEntity.java
@@ -39,10 +39,10 @@ public class DocumentEntity extends BaseUUIDEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private UserEntity user;
+    private UserEntity userEntity;
 
     public UUID getUserId() {
-        return user.getId();
+        return userEntity.getId();
     }
 
     public void changeDocument(String previewImagePath, String content) {

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/feedback/persistence/entity/FeedBackEntity.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/feedback/persistence/entity/FeedBackEntity.java
@@ -30,7 +30,7 @@ public class FeedBackEntity {
     @MapsId("documentId")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "document_id", nullable = false)
-    private DocumentEntity document;
+    private DocumentEntity documentEntity;
 
     @Column(columnDefinition = "VARCHAR(255)", nullable = false)
     private String comment;

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/my_skill/persistence/MySkillPersistenceAdapter.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/my_skill/persistence/MySkillPersistenceAdapter.java
@@ -24,7 +24,7 @@ public class MySkillPersistenceAdapter implements CommandMySkillPort {
     private final MySkillMapper mySkillMapper;
 
     public boolean existsByTagId(UUID tagId) {
-        return mySkillRepository.existsByTagId(tagId);
+        return mySkillRepository.existsByTagEntityId(tagId);
     }
 
     @Override
@@ -39,7 +39,7 @@ public class MySkillPersistenceAdapter implements CommandMySkillPort {
 
     @Override
     public void deleteAllMySKillByUserId(UUID userId) {
-        mySkillRepository.deleteAllByUserId(userId);
+        mySkillRepository.deleteAllByUserEntityId(userId);
     }
 
     private boolean existsTag(UUID tagId) {

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/my_skill/persistence/MySkillRepository.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/my_skill/persistence/MySkillRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.repository.CrudRepository;
 import java.util.UUID;
 
 public interface MySkillRepository extends CrudRepository<MySkillEntity, MySkillEntityId> {
-    boolean existsByTagId(UUID tagId);
-    void deleteAllByUserId(UUID userId);
+    boolean existsByTagEntityId(UUID tagId);
+    void deleteAllByUserEntityId(UUID userId);
 }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/my_skill/persistence/entity/MySkillEntity.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/my_skill/persistence/entity/MySkillEntity.java
@@ -30,12 +30,12 @@ public class MySkillEntity {
     @MapsId("userId")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private UserEntity user;
+    private UserEntity userEntity;
 
     @MapsId("tagId")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id", nullable = false)
-    private TagEntity tag;
+    private TagEntity tagEntity;
 
 
 }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/student/mapper/StudentMapper.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/student/mapper/StudentMapper.java
@@ -36,7 +36,7 @@ public class StudentMapper {
 			.orElseThrow(() -> TagNotFoundException.EXCEPTION);
 
 		return StudentEntity.builder()
-			.user(userEntity)
+			.userEntity(userEntity)
 			.grade(student.getGrade())
 			.classNum(student.getClassNum())
 			.number(student.getNumber())

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/student/persistence/StudentPersistenceAdapter.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/student/persistence/StudentPersistenceAdapter.java
@@ -12,7 +12,7 @@ public class StudentPersistenceAdapter {
 	private final StudentRepository studentRepository;
 
 	public boolean existsByTagId(UUID tagId) {
-		return studentRepository.existsByTagId(tagId);
+		return studentRepository.existsByTagEntityId(tagId);
 	}
 
 }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/student/persistence/StudentRepository.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/student/persistence/StudentRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.repository.CrudRepository;
 import java.util.UUID;
 
 public interface StudentRepository extends CrudRepository<StudentEntity, Long> {
-    boolean existsByTagId(UUID tagId);
+    boolean existsByTagEntityId(UUID tagId);
 }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/student/persistence/entity/StudentEntity.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/student/persistence/entity/StudentEntity.java
@@ -33,7 +33,7 @@ public class StudentEntity {
 	@MapsId
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
-	private UserEntity user;
+	private UserEntity userEntity;
 
 	@Column(columnDefinition = "TINYINT", nullable = false)
 	private Integer grade;

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/tag/presentation/TagWebAdapter.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/tag/presentation/TagWebAdapter.java
@@ -54,7 +54,7 @@ public class TagWebAdapter {
     }
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping
+    @PostMapping("/my-skill")
     public void setMySkill(@RequestBody @Valid WebAddMySkillRequest request) {
         addMySkillPort.execute(new DomainAddMySkillRequest(request.getTagList()));
     }


### PR DESCRIPTION
## 참고사항

1. Repository에서 findByUserId라는 메소드를 작성하면 Entity를 스캔하는데 그 때 Entity class에 getUserId()와 같은 getter method가 존재한다면 JPA에서는 해당 엔티티에서 UserId라는 필드를 찾게되고 없으니까 에러가 남, 에러가 BaseUUIDEntity에서 나는 경우는 상위 엔티티까지 탐색을 해서 그런거임.
따라서 Entity에 getUserId는 그대로 놔두고, field 명에 Entity postfix를 붙이고, Repository의 method명에도 붙이면 JPA가 혼동할 일이없으므로 그렇게 변경함.


2. TagWebAdapter에서 발생한 Exception은 동일한 prefix의 Api가 존재해서 발생한 것임.
my-skill을 안붙여서 발생

close #97