### PR TITLE
🔀 :: (#43) 피드백 생성

### DIFF
--- a/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/feedback/spi/CommandFeedbackPort.java
+++ b/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/feedback/spi/CommandFeedbackPort.java
@@ -4,4 +4,5 @@ import kr.hs.entrydsm.yapaghetti.domain.feedback.domain.Feedback;
 
 public interface CommandFeedbackPort {
 	void updateFeedback(Feedback feedback);
+	void saveFeedback(Feedback feedback);
 }

--- a/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/api/CreateFeedbackPort.java
+++ b/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/api/CreateFeedbackPort.java
@@ -1,0 +1,10 @@
+package kr.hs.entrydsm.yapaghetti.domain.teacher.api;
+
+
+import kr.hs.entrydsm.yapaghetti.domain.teacher.api.dto.request.DomainCreateFeedbackRequest;
+
+public interface CreateFeedbackPort {
+
+    void createFeedback(DomainCreateFeedbackRequest request);
+
+}

--- a/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/api/dto/request/DomainCreateFeedbackRequest.java
+++ b/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/api/dto/request/DomainCreateFeedbackRequest.java
@@ -10,7 +10,6 @@ import java.util.UUID;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DomainCreateFeedbackRequest {
 

--- a/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/api/dto/request/DomainCreateFeedbackRequest.java
+++ b/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/api/dto/request/DomainCreateFeedbackRequest.java
@@ -1,0 +1,23 @@
+package kr.hs.entrydsm.yapaghetti.domain.teacher.api.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DomainCreateFeedbackRequest {
+
+    private UUID studentId;
+
+    private Integer sequence;
+
+    private String comment;
+
+}

--- a/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/usecase/CreateFeedbackUseCase.java
+++ b/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/usecase/CreateFeedbackUseCase.java
@@ -1,0 +1,37 @@
+package kr.hs.entrydsm.yapaghetti.domain.teacher.usecase;
+
+import kr.hs.entrydsm.yapaghetti.annotation.UseCase;
+import kr.hs.entrydsm.yapaghetti.domain.document.domain.DocumentType;
+import kr.hs.entrydsm.yapaghetti.domain.document.spi.QueryDocumentPort;
+import kr.hs.entrydsm.yapaghetti.domain.feedback.domain.Feedback;
+import kr.hs.entrydsm.yapaghetti.domain.feedback.spi.CommandFeedbackPort;
+import kr.hs.entrydsm.yapaghetti.domain.teacher.api.CreateFeedbackPort;
+import kr.hs.entrydsm.yapaghetti.domain.teacher.api.dto.request.DomainCreateFeedbackRequest;
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@UseCase
+public class CreateFeedbackUseCase implements CreateFeedbackPort {
+
+    private final CommandFeedbackPort commandFeedbackPort;
+
+    private final QueryDocumentPort queryDocumentPort;
+
+    @Override
+    public void createFeedback(DomainCreateFeedbackRequest request) {
+
+        UUID documentId = queryDocumentPort.queryDocumentByUserIdAndType(
+                request.getStudentId(), DocumentType.STAY
+        ).getId();
+
+        commandFeedbackPort.saveFeedback(
+                Feedback.builder()
+                        .documentId(documentId)
+                        .sequence(request.getSequence())
+                        .comment(request.getComment())
+                        .build()
+        );
+    }
+}

--- a/yapaghetti-application/src/test/java/kr/hs/entrydsm/yapaghetti/domain/teacher/usecase/CreateFeedbackTest.java
+++ b/yapaghetti-application/src/test/java/kr/hs/entrydsm/yapaghetti/domain/teacher/usecase/CreateFeedbackTest.java
@@ -1,0 +1,56 @@
+package kr.hs.entrydsm.yapaghetti.domain.teacher.usecase;
+
+import kr.hs.entrydsm.yapaghetti.domain.document.domain.Document;
+import kr.hs.entrydsm.yapaghetti.domain.document.domain.DocumentType;
+import kr.hs.entrydsm.yapaghetti.domain.document.spi.QueryDocumentPort;
+import kr.hs.entrydsm.yapaghetti.domain.feedback.spi.CommandFeedbackPort;
+import kr.hs.entrydsm.yapaghetti.domain.teacher.api.dto.request.DomainCreateFeedbackRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+public class CreateFeedbackTest {
+
+    @Mock
+    CommandFeedbackPort commandFeedbackPort;
+
+    @Mock
+    QueryDocumentPort queryDocumentPort;
+
+    @InjectMocks
+    CreateFeedbackUseCase createFeedbackUseCase;
+
+    @Mock
+    DomainCreateFeedbackRequest request;
+
+    @Test
+    void testCreateFeedback() {
+        UUID studentId = UUID.randomUUID();
+        Integer sequence = 1;
+        String comment = "이 부분 알잘딱 실패!!";
+
+        given(request.getStudentId())
+                .willReturn(studentId);
+
+        given(request.getSequence())
+                .willReturn(sequence);
+
+        given(request.getComment())
+                .willReturn(comment);
+
+        given(queryDocumentPort.queryDocumentByUserIdAndType(studentId, DocumentType.STAY))
+                .willReturn(Document.builder().build());
+
+        createFeedbackUseCase.createFeedback(request);
+
+    }
+
+}

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/feedback/persistence/FeedbackPersistenceAdapter.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/feedback/persistence/FeedbackPersistenceAdapter.java
@@ -30,4 +30,12 @@ public class FeedbackPersistenceAdapter implements QueryFeedbackPort, CommandFee
             feedbackMapper.domainToEntity(feedback)
         );
     }
+
+    @Override
+    public void saveFeedback(Feedback feedback) {
+        feedbackRepository.save(
+                feedbackMapper.domainToEntity(feedback)
+        );
+    }
+
 }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/presentation/TeacherWebAdapter.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/presentation/TeacherWebAdapter.java
@@ -1,0 +1,36 @@
+package kr.hs.entrydsm.yapaghetti.domain.teacher.presentation;
+
+import kr.hs.entrydsm.yapaghetti.domain.teacher.api.CreateFeedbackPort;
+import kr.hs.entrydsm.yapaghetti.domain.teacher.api.dto.request.DomainCreateFeedbackRequest;
+import kr.hs.entrydsm.yapaghetti.domain.teacher.presentation.dto.request.WebCreateFeedbackRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RequestMapping("/teachers")
+@RestController
+public class TeacherWebAdapter {
+
+    private final CreateFeedbackPort createFeedbackPort;
+
+    @PostMapping("/feedback/{student-id}")
+    public void createFeedback(@PathVariable("student-id") @NotBlank UUID studentId,
+                               @RequestBody @Valid WebCreateFeedbackRequest request) {
+        createFeedbackPort.createFeedback(
+                DomainCreateFeedbackRequest.builder()
+                        .studentId(studentId)
+                        .sequence(request.getSequence())
+                        .comment(request.getComment())
+                        .build()
+        );
+    }
+
+}

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/presentation/TeacherWebAdapter.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/presentation/TeacherWebAdapter.java
@@ -4,10 +4,12 @@ import kr.hs.entrydsm.yapaghetti.domain.teacher.api.CreateFeedbackPort;
 import kr.hs.entrydsm.yapaghetti.domain.teacher.api.dto.request.DomainCreateFeedbackRequest;
 import kr.hs.entrydsm.yapaghetti.domain.teacher.presentation.dto.request.WebCreateFeedbackRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -21,6 +23,7 @@ public class TeacherWebAdapter {
 
     private final CreateFeedbackPort createFeedbackPort;
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/feedback/{student-id}")
     public void createFeedback(@PathVariable("student-id") @NotBlank UUID studentId,
                                @RequestBody @Valid WebCreateFeedbackRequest request) {

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/presentation/dto/request/WebCreateFeedbackRequest.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/teacher/presentation/dto/request/WebCreateFeedbackRequest.java
@@ -1,0 +1,18 @@
+package kr.hs.entrydsm.yapaghetti.domain.teacher.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class WebCreateFeedbackRequest {
+    
+    @NotNull
+    private Integer sequence;
+    
+    @NotBlank
+    private String comment;
+}

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/global/security/SecurityConfig.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/global/security/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.POST, "/users/auth").permitAll()
                 .antMatchers(HttpMethod.PATCH, "/users/first-password").hasAnyRole(STUDENT, TEACHER, MOU)
                 .antMatchers(HttpMethod.PATCH, "/users/information").hasAnyRole(STUDENT, TEACHER, MOU)
+                .antMatchers(HttpMethod.POST, "/teachers/feedback/{student-id}").hasRole(TEACHER)
                 .antMatchers(HttpMethod.POST, "/tags").hasRole(TEACHER)
                 .antMatchers(HttpMethod.DELETE, "/tags/{tag-id}").hasRole(TEACHER)
                 .antMatchers(HttpMethod.POST, "/tags/my-skill").hasRole(STUDENT)


### PR DESCRIPTION
close #43 

----
- FeedbackPersistanceAdapter에서 updateFeedback과 saveFeedback의 로직이 동일합니다.
- 아래는 위 문제에 대한 생각입니다

1. 두 개 다 남길 경우
- 서로 목적에 맞게 구별되는 장점이 존재 
- 동일한 로직의 불편함

2. 하나만 존재시킬 경우
- 업데이트와 생성에 해당하는 함수명을 지어야 함, ex) saveFeedback
- 동일한 로직을 없앨 수 있음



