### PR TITLE
🔀 :: (#245) 이메일 인증번호 발송api response값 추가

### DIFF
--- a/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/auth/api/SendEmailAuthCodePort.java
+++ b/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/auth/api/SendEmailAuthCodePort.java
@@ -1,5 +1,7 @@
 package kr.hs.entrydsm.yapaghetti.domain.auth.api;
 
+import kr.hs.entrydsm.yapaghetti.domain.auth.api.dto.response.SendEmailAuthCodeResponse;
+
 public interface SendEmailAuthCodePort {
-    void execute();
+    SendEmailAuthCodeResponse execute();
 }

--- a/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/auth/api/dto/response/SendEmailAuthCodeResponse.java
+++ b/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/auth/api/dto/response/SendEmailAuthCodeResponse.java
@@ -1,0 +1,11 @@
+package kr.hs.entrydsm.yapaghetti.domain.auth.api.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SendEmailAuthCodeResponse {
+
+	private final String email;
+}

--- a/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/auth/usecase/SendEmailAuthCodeUseCase.java
+++ b/yapaghetti-application/src/main/java/kr/hs/entrydsm/yapaghetti/domain/auth/usecase/SendEmailAuthCodeUseCase.java
@@ -2,6 +2,7 @@ package kr.hs.entrydsm.yapaghetti.domain.auth.usecase;
 
 import kr.hs.entrydsm.yapaghetti.annotation.UseCase;
 import kr.hs.entrydsm.yapaghetti.domain.auth.api.SendEmailAuthCodePort;
+import kr.hs.entrydsm.yapaghetti.domain.auth.api.dto.response.SendEmailAuthCodeResponse;
 import kr.hs.entrydsm.yapaghetti.domain.auth.domain.AuthCode;
 import kr.hs.entrydsm.yapaghetti.domain.auth.exception.AuthCodeAlreadyVerifiedException;
 import kr.hs.entrydsm.yapaghetti.domain.auth.exception.AuthCodeOverLimitException;
@@ -30,7 +31,7 @@ public class SendEmailAuthCodeUseCase implements SendEmailAuthCodePort {
     private final GetAuthPropertiesPort getAuthPropertiesPort;
 
     @Override
-    public void execute() {
+    public SendEmailAuthCodeResponse execute() {
         Long authTime = getAuthPropertiesPort.getAuthTime();
         String authCode = generateRandomStringPort.getAuthCode();
         AuthCode emailAuthCode;
@@ -64,5 +65,7 @@ public class SendEmailAuthCodeUseCase implements SendEmailAuthCodePort {
         commandAuthCodePort.saveAuthCode(emailAuthCode);
 
         sendMailPort.sendAuthCode(value, authCode);
+
+        return new SendEmailAuthCodeResponse(value);
     }
 }

--- a/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/auth/presentation/AuthWebAdapter.java
+++ b/yapaghetti-infrastructure/src/main/java/kr/hs/entrydsm/yapaghetti/domain/auth/presentation/AuthWebAdapter.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotBlank;
 import kr.hs.entrydsm.yapaghetti.domain.auth.api.SendEmailAuthCodePort;
 import kr.hs.entrydsm.yapaghetti.domain.auth.api.SendPhoneNumberAuthCodePort;
 import kr.hs.entrydsm.yapaghetti.domain.auth.api.VerifyAuthCodePort;
+import kr.hs.entrydsm.yapaghetti.domain.auth.api.dto.response.SendEmailAuthCodeResponse;
 import kr.hs.entrydsm.yapaghetti.domain.auth.presentation.dto.request.SendPhoneNumberAuthCodeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,8 +24,8 @@ public class AuthWebAdapter {
 	private final VerifyAuthCodePort verifyAuthCodePort;
 
 	@PostMapping("/email")
-	public void sendEmailAuthCode() {
-		sendEmailAuthCodePort.execute();
+	public SendEmailAuthCodeResponse sendEmailAuthCode() {
+		return sendEmailAuthCodePort.execute();
 	}
 
 	@PostMapping("/phone-number")


### PR DESCRIPTION
이메일 인증번호 발송은 토큰에서 정보를 뺴와서 하는데 인증번호 확인은 email이 필요해서 response값에 email을 추가했습니다.

close #245 